### PR TITLE
Thanks for releasing CMIndexBar. Here is a bug fix I think you will like.

### DIFF
--- a/CMIndexBar.m
+++ b/CMIndexBar.m
@@ -128,11 +128,19 @@
 - (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event
 {
 	[super touchesEnded:touches withEvent:event];
-
-	UIView *backgroundView = (UIView*)[self viewWithTag:767];
-	[backgroundView removeFromSuperview];
+  [self touchesEndedOrCancelled:touches withEvent:event];
 }
 
+- (void)touchesCancelled:(NSSet *)touches withEvent:(UIEvent *)event
+{
+  [super touchesCancelled:touches withEvent:event];
+  [self touchesEndedOrCancelled:touches withEvent:event];
+}
+
+- (void) touchesEndedOrCancelled:(NSSet *)touches withEvent:(UIEvent *)event {
+ 	UIView *backgroundView = (UIView*)[self viewWithTag:767];
+	[backgroundView removeFromSuperview]; 
+}
 
 - (void)touchesBegan:(NSSet *)touches withEvent:(UIEvent *)event
 {


### PR DESCRIPTION
When you start a touch event, and interrupt it (like hitting the home
button), the index bar would be left in an inconsistent state and be
unusable. With touchesCancelled, the index bar always recovers.
